### PR TITLE
Use https:// for riscv-test-env submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "env"]
 	path = env
-	url = git://github.com/ucb-bar/riscv-test-env.git
+	url = https://github.com/riscv/riscv-test-env.git


### PR DESCRIPTION
Fixes https://github.com/sifive/freedom/issues/9.

As described in the Pro Git Book, the [git:// protocol](https://git-scm.com/book/ch4-1.html#The-Git-Protocol) might be blocked by corporate firewalls. I've changed the submodule pointer to use the `https://` protocol like everything else in `rocket-chip`. I also noticed that `ucb-bar/riscv-test-env` redirects to `riscv/riscv-test-env`, so I also went ahead and updated that.