### PR TITLE
Bump SBT to 1.8.2 and remove maxpermize=128 in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Convenience Makefile
 
-SBT ?= java -Xmx1G -Xss8M -XX:MaxPermSize=128M -jar sbt-launch.jar
+SBT ?= java -Xmx1G -Xss8M -jar sbt-launch.jar
 RTL_CONFIG := DefaultConfig
 C_SIM := ../emulator/emulator-rocketchip-$(RTL_CONFIG)
 R_SIM := ../vsim/simv-rocketchip-$(RTL_CONFIG)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.8.2


### PR DESCRIPTION
Updated the changes to support torture for Chipyard 1.10.0